### PR TITLE
fix for while loop condition in getXY

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -136,7 +136,7 @@ vector<double> getXY(double s, double d, vector<double> maps_s, vector<double> m
 {
 	int prev_wp = -1;
 
-	while(s > maps_s[prev_wp+1] && (prev_wp < (int)(maps_s.size()-1) ))
+	while(s > maps_s[prev_wp+1] && (prev_wp < (int)(maps_s.size()-2) ))
 	{
 		prev_wp++;
 	}


### PR DESCRIPTION
the second part of the while condition needs to be fixed. otherwise we can get ``prev_wp == maps_s.size()-1`` which leads to an invalid memory access at the next check of the first part of the while condition ``s > map_s[prev_wp+1]``

This error only occurs for x,y positions beyond the last waypoint.