### PR TITLE
fix closestWaypoint to return valid index

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,7 +78,7 @@ int NextWaypoint(double x, double y, double theta, vector<double> maps_x, vector
 		closestWaypoint++;
 	}
 
-	return closestWaypoint;
+	return closestWaypoint % maps_x.size();
 
 }
 


### PR DESCRIPTION
the returned index given by closestWaypoint should not increase beyond the maximum index

I'd recommend writing tests to avoid errors like these, in fact I only noticed because I was porting this to python and wrote some tests for that.