### PR TITLE
Fix computing angle to the closest waypoint

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,9 +71,9 @@ int NextWaypoint(double x, double y, double theta, const vector<double> &maps_x,
 
 	double heading = atan2( (map_y-y),(map_x-x) );
 
-	double angle = abs(theta-heading);
+	double angle = abs(atan2(sin(theta - heading), cos(theta - heading)));
 
-	if(angle > pi()/4)
+	if(angle > pi()/2)
 	{
 		closestWaypoint++;
 	}


### PR DESCRIPTION
Angle must be normalized for the correct waypoint classification. Before
this change, if the car angle equals 3 and the waypoint angle equals -3,
the difference between them becomes 6. However, the actual difference
must be equal to 0.28.
After this change, the difference lies in the range [0, pi]. A
difference less than pi/2 means a forward waypoint. A difference in
the range [pi/2, pi] means a backward waypoint.