### PR TITLE
Add OpenSSL and zlib development packges to uWebSockets install script

### DIFF
--- a/install-ubuntu.sh
+++ b/install-ubuntu.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-sudo apt-get install libuv1-dev
+sudo apt-get install libuv1-dev libssl-dev libz-dev
 git clone https://github.com/uWebSockets/uWebSockets 
 cd uWebSockets
 git checkout e94b6e1


### PR DESCRIPTION
Installing the uWebSockets library will not succeed without the OpenSSL and libz build dependencies installed. This change will ensure that they get are installed before attempting to compile uWebSockets.