### PR TITLE
fix mac-install.sh by explicit openssl version

### DIFF
--- a/install-mac.sh
+++ b/install-mac.sh
@@ -7,7 +7,8 @@ patch CMakeLists.txt < ../cmakepatch.txt
 mkdir build
 export PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig 
 cd build
-cmake ..
+OPENSSL_VERSION=`openssl version -v | cut -d' ' -f2`
+cmake -DOPENSSL_ROOT_DIR=$(brew --cellar openssl)/$OPENSSL_VERSION -DOPENSSL_LIBRARIES=$(brew --cellar openssl)/$OPENSSL_VERSION/lib ..
 make 
 sudo make install
 cd ..


### PR DESCRIPTION
Issue in recent uWebSocket building from source on Mac via script. 
Explicitly call local openssl version.

Solution similar to https://github.com/udacity/CarND-Kidnapped-Vehicle-Project/blob/db26369f47ae72fedf0e21bfc6431256c95f5156/install-mac.sh

Fixes #51 